### PR TITLE
(enh/fix): mariadbd version and start mariadb using mysqld_safe

### DIFF
--- a/bin/mysql-sync-bigdb.sh
+++ b/bin/mysql-sync-bigdb.sh
@@ -395,7 +395,7 @@ fi
 ###
 
 echo "Start MySQL Slave"
-$USER_SUDO ssh $slave_hostname "$MYSQL_START &"
+$USER_SUDO ssh $slave_hostname -- "$MYSQL_START &"
 i=0
 until mysqlshow -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" > /dev/null 2>&1; do
         if [ "$i" -gt "$STOP_TIMEOUT" ] ; then


### PR DESCRIPTION
For 21.10/21.04

Since MariaDB 10.5, the name of mariadb daemon have changed.

Plus, the sync-big-db now restart MySQL using mysqld_safe just like the cluster manage it.