### PR TITLE
Fix depends issues for debian 11 - PS-44

### DIFF
--- a/ci/debian/control
+++ b/ci/debian/control
@@ -30,6 +30,6 @@ Description: This add-on is built to manage a failover solution for Centreon.
 Depends:
   ${misc:Depends}, 
   ${shlibs:Depends},
-  resources-agents,
+  resource-agents,
   centreon-ha (>= ${centreon:version}~),
   centreon-web (>= ${centreon:version}~)


### PR DESCRIPTION
## Description
Problem with the name of the centeron-ha-web dependencies
They are not resources-agents, but resource-agents.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects, breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)