### PR TITLE
PS-48 (Enh) Add actual Master/Slave information in output

### DIFF
--- a/bin/mysql-check-status.sh
+++ b/bin/mysql-check-status.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ###################################################
-# Centreon                                 Jan 2020 
+# Centreon                                Sept 2022
 #
 # Checks the replication state
 #
@@ -39,8 +39,16 @@ display_result_one()
 
 display_result()
 {
-	display_result_one $connexion_status_server1 "Connection Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
-	display_result_one $connexion_status_server2 "Connection Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+	if [ $slave_address == $DBHOSTNAMEMASTER ];then
+		display_result_one $connexion_status_server2 "Connection MASTER Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+		display_result_one $connexion_status_server1 "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+	elif [ $slave_address == $DBHOSTNAMESLAVE ];then
+		display_result_one $connexion_status_server1 "Connection MASTER Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+		display_result_one $connexion_status_server2 "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+	else
+		display_result_one $connexion_status_server1 "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+		display_result_one $connexion_status_server2 "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+	fi
 	display_result_one $slave_status "Slave Thread Status" "$slave_status_error"
 	display_result_one $position_status "Position Status" "$position_status_error"
 }

--- a/bin/mysql-check-status.sh
+++ b/bin/mysql-check-status.sh
@@ -39,15 +39,15 @@ display_result_one()
 
 display_result()
 {
-	if [ $slave_address == $DBHOSTNAMEMASTER ];then
-		display_result_one $connexion_status_server2 "Connection MASTER Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
-		display_result_one $connexion_status_server1 "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
-	elif [ $slave_address == $DBHOSTNAMESLAVE ];then
-		display_result_one $connexion_status_server1 "Connection MASTER Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
-		display_result_one $connexion_status_server2 "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+	if [[ "$slave_address" == "$DBHOSTNAMEMASTER" ]] ; then
+		display_result_one "$connexion_status_server2" "Connection MASTER Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+		display_result_one "$connexion_status_server1" "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+	elif [[ "$slave_address" == "$DBHOSTNAMESLAVE" ]] ; then
+		display_result_one "$connexion_status_server1" "Connection MASTER Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+		display_result_one "$connexion_status_server2" "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
 	else
-		display_result_one $connexion_status_server1 "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
-		display_result_one $connexion_status_server2 "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
+		display_result_one "$connexion_status_server1" "Connection SLAVE Status '$DBHOSTNAMEMASTER'" "$report_connexion1"
+		display_result_one "$connexion_status_server2" "Connection SLAVE Status '$DBHOSTNAMESLAVE'" "$report_connexion2"
 	fi
 	display_result_one $slave_status "Slave Thread Status" "$slave_status_error"
 	display_result_one $position_status "Position Status" "$position_status_error"


### PR DESCRIPTION
## Description

Add simply Master/Slave information on the output "Connection status" for two hosts
https://centreon.atlassian.net/browse/PS-48

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Have a functional Centreon-HA (2 nodes or 4 nodes)
- run the script /usr/share/centreon-ha/bin/mysql-check-status.sh
You should have a result like this:
```
Connection MASTER Status 'centreon-ha2-el7-pri' [OK]
Connection SLAVE Status 'centreon-ha2-el7-sec' [OK]
Slave Thread Status [OK]
Position Status [OK]
```
- move master to slave
- re run the script
You should have a result like this:
```
Connection MASTER Status 'centreon-ha2-el7-sec' [OK]
Connection SLAVE Status 'centreon-ha2-el7-pri' [OK]
Slave Thread Status [OK]
Position Status [OK]
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
