### PR TITLE
Update centreon-ha-web.install

### DIFF
--- a/ci/debian/centreon-ha-web.install
+++ b/ci/debian/centreon-ha-web.install
@@ -1,5 +1,4 @@
 etc/centreon-gorgone/config.d/cron.d/*      etc/centreon-gorgone/config.d/cron.d
-etc/centreon-ha/centreon_central_sync.pm    etc/centreon-ha
 etc/sudoers.d/centreon-cluster              etc/sudoers.d
 etc/sysconfig/*                             etc/default
 systemd/*                                   lib/systemd/system


### PR DESCRIPTION
## Description

Remove the replacing of centreon_central_sync because is already installed with centreon-ha-common.
We have errors on installation of packs like : 

`attempt to replace "/etc/centreon-ha/centreon_central_sync.pm", which also belongs to the centreon-ha-common 22.10.0-bullseye package`

The files in `/etc/centreon-ha` are installed with centreon-ha-common which is a dependency of centreon-ha-web

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
